### PR TITLE
Update the path creation to include the full arch for M1 macs so it creates the correct file path

### DIFF
--- a/pychromedriver/__init__.py
+++ b/pychromedriver/__init__.py
@@ -24,7 +24,7 @@ def _get_filename():
         else:
             raise Exception('OS not supported')
 
-        path += '64' if arch.endswith('64') else '32'
+        path += "_" + arch if arch.endswith('64') else '32'
         if not os.path.exists(path):
             raise FileNotFoundError('ChromeDriver for {}({}) '
                     'is not found.'.format(sys, arch))


### PR DESCRIPTION
**Why**

At the moment, I am seeing errors like this for M1 Macs that are using PyChromedriver.
`packages/pychromedriver/__init__.py", line 29, in _get_filename
  raise FileNotFoundError('ChromeDriver for {}({}) '
FileNotFoundError: ChromeDriver for Darwin(arm64) is not found.`

This is due to the path string created not matching the file path for chromedriver on M1 Macbooks (Apple Chip).

This is the correct file path 
![image](https://user-images.githubusercontent.com/45559854/220334343-3506c450-3374-4ccf-a458-68d416962821.png)

The file path currently being created is:
`...../python3.9/site-packages/pychromedriver/chromedriver_mac64`

**What**

Use the arch full name to create the correct path string so the correct file is found.
